### PR TITLE
채팅 접속자수 초기화 숫자 변경

### DIFF
--- a/src/main/java/com/hermez/farrot/chat/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/hermez/farrot/chat/chatroom/entity/ChatRoom.java
@@ -54,7 +54,7 @@ public class ChatRoom {
     public static ChatRoom makeChatRoom(Member sender, Product product){
       return ChatRoom.builder()
           .sender(sender)
-          .connect(1)
+          .connect(0)
           .product(product)
           .createdAt(LocalDateTime.now())
           .build();


### PR DESCRIPTION
## 📘요약과 목적

- 채팅 접속자수 초기화 숫자 변경

## ☑️변경내용

- 채팅방 처음 만들어지면 접속자수 1->0으로 변경

## 🌐전달 내용

- 채팅방 처음 만들어지면 접속자수 1->0으로 변경